### PR TITLE
allauth installled - email verification added - allauth templates mov…

### DIFF
--- a/protect_multitool/settings.py
+++ b/protect_multitool/settings.py
@@ -40,11 +40,14 @@ CSRF_TRUSTED_ORIGINS = [
 
 INSTALLED_APPS = [
     'django.contrib.admin',
-    'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.auth',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
     'account_home',
     'game',
     'home_page',
@@ -59,6 +62,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
 
 ROOT_URLCONF = 'protect_multitool.urls'
@@ -78,6 +82,17 @@ TEMPLATES = [
         },
     },
 ]
+
+AUTHENTICATION_BACKENDS = [
+    # Needed to login by username in Django admin, regardless of `allauth`
+    'django.contrib.auth.backends.ModelBackend',
+
+    # `allauth` specific authentication methods, such as login by email
+    'allauth.account.auth_backends.AuthenticationBackend',
+]
+
+SITE_ID = 1
+
 
 WSGI_APPLICATION = 'protect_multitool.wsgi.application'
 
@@ -131,3 +146,22 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = True
+ACCOUNT_USERNAME_MIN_LENGTH = 4
+LOGIN_URL = '/accounts/login/'
+LOGIN_REDIRECT_URL = '/'
+
+if 'DEVELOPMENT' in os.environ:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+else:
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = 'smtp.gmail.com'
+    EMAIL_PORT = 587
+    EMAIL_USE_TLS = True
+    EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+    EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
+    DEFAULT_FROM_EMAIL = os.environ.get('EMAIL_HOST_USER')

--- a/protect_multitool/urls.py
+++ b/protect_multitool/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/', include('allauth.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,11 @@
 asgiref==3.8.1
-Django==5.1.5
-python-decouple==3.8
-sqlparse==0.5.3
-asgiref==3.8.1
 awscli==1.36.21
 boto3==1.35.80
 botocore==1.35.80
 colorama==0.4.6
 crispy-bootstrap4==2024.10
 dj-database-url==0.5.0
+Django==5.1.5
 django-allauth==0.57.2
 django-crispy-forms==2.3
 django-storages==1.14.4
@@ -21,8 +18,10 @@ psycopg2==2.9.10
 psycopg2-binary==2.9.10
 pyasn1==0.6.1
 PyJWT==2.10.1
+python-decouple==3.8
 python3-openid==3.2.0
 requests-oauthlib==2.0.0
 rsa==4.7.2
 s3transfer==0.10.4
+sqlparse==0.5.3
 whitenoise==6.7.0

--- a/templates/allauth/account/account_inactive.html
+++ b/templates/allauth/account/account_inactive.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Account Inactive" %}{% endblock head_title %}
+
+{% block content %}
+<h1>{% trans "Account Inactive" %}</h1>
+
+<p>{% trans "This account is inactive." %}</p>
+{% endblock content %}

--- a/templates/allauth/account/email.html
+++ b/templates/allauth/account/email.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Email Addresses" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Email Addresses" %}</h1>
+{% if emailaddresses %}
+<p>{% trans 'The following email addresses are associated with your account:' %}</p>
+
+<form action="{% url 'account_email' %}" class="email_list" method="post">
+{% csrf_token %}
+<fieldset class="blockLabels">
+
+  {% for emailaddress in emailaddresses %}
+<div class="ctrlHolder">
+      <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
+
+      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or emailaddresses|length == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+
+{{ emailaddress.email }}
+    {% if emailaddress.verified %}
+    <span class="verified">{% trans "Verified" %}</span>
+    {% else %}
+    <span class="unverified">{% trans "Unverified" %}</span>
+    {% endif %}
+      {% if emailaddress.primary %}<span class="primary">{% trans "Primary" %}</span>{% endif %}
+</label>
+</div>
+  {% endfor %}
+
+<div class="buttonHolder">
+      <button class="secondaryAction" type="submit" name="action_primary" >{% trans 'Make Primary' %}</button>
+      <button class="secondaryAction" type="submit" name="action_send" >{% trans 'Re-send Verification' %}</button>
+      <button class="primaryAction" type="submit" name="action_remove" >{% trans 'Remove' %}</button>
+</div>
+
+</fieldset>
+</form>
+
+{% else %}
+{% include "account/snippets/warn_no_email.html" %}
+{% endif %}
+
+  {% if can_add_email %}
+    <h2>{% trans "Add Email Address" %}</h2>
+
+    <form method="post" action="{% url 'account_email' %}" class="add_email">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button name="action_add" type="submit">{% trans "Add Email" %}</button>
+    </form>
+  {% endif %}
+
+{% endblock content %}
+
+
+{% block extra_body %}
+<script type="text/javascript">
+(function() {
+  var message = "{% trans 'Do you really want to remove the selected email address?' %}";
+  var actions = document.getElementsByName('action_remove');
+  if (actions.length) {
+    actions[0].addEventListener("click", function(e) {
+      if (! confirm(message)) {
+        e.preventDefault();
+      }
+    });
+  }
+})();
+</script>
+{% endblock extra_body %}

--- a/templates/allauth/account/email/account_already_exists_message.txt
+++ b/templates/allauth/account/email/account_already_exists_message.txt
@@ -1,0 +1,13 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans %}You are receiving this email because you or someone else tried to signup for an
+account using email address:
+
+{{ email }}
+
+However, an account using that email address already exists.  In case you have
+forgotten about this, please use the password forgotten procedure to recover
+your account:
+
+{{ password_reset_url }}{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/templates/allauth/account/email/account_already_exists_subject.txt
+++ b/templates/allauth/account/email/account_already_exists_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Account Already Exists{% endblocktrans %}
+{% endautoescape %}

--- a/templates/allauth/account/email/base_message.txt
+++ b/templates/allauth/account/email/base_message.txt
@@ -1,0 +1,7 @@
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Hello from {{ site_name }}!{% endblocktrans %}
+
+{% block content %}{% endblock content %}
+
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using {{ site_name }}!
+{{ site_domain }}{% endblocktrans %}
+{% endautoescape %}

--- a/templates/allauth/account/email/email_confirmation_message.txt
+++ b/templates/allauth/account/email/email_confirmation_message.txt
@@ -1,0 +1,7 @@
+{% extends "account/email/base_message.txt" %}
+{% load account %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because user {{ user_display }} has given your email address to register an account on {{ site_domain }}.
+
+To confirm this is correct, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/templates/allauth/account/email/email_confirmation_signup_message.txt
+++ b/templates/allauth/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.txt" %}

--- a/templates/allauth/account/email/email_confirmation_signup_subject.txt
+++ b/templates/allauth/account/email/email_confirmation_signup_subject.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_subject.txt" %}

--- a/templates/allauth/account/email/email_confirmation_subject.txt
+++ b/templates/allauth/account/email/email_confirmation_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Please Confirm Your Email Address{% endblocktrans %}
+{% endautoescape %}

--- a/templates/allauth/account/email/password_reset_key_message.txt
+++ b/templates/allauth/account/email/password_reset_key_message.txt
@@ -1,0 +1,9 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans %}You're receiving this email because you or someone else has requested a password reset for your user account.
+It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
+
+{{ password_reset_url }}{% if username %}
+
+{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}{% endif %}{% endautoescape %}{% endblock content %}

--- a/templates/allauth/account/email/password_reset_key_subject.txt
+++ b/templates/allauth/account/email/password_reset_key_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password Reset Email{% endblocktrans %}
+{% endautoescape %}

--- a/templates/allauth/account/email/unknown_account_message.txt
+++ b/templates/allauth/account/email/unknown_account_message.txt
@@ -1,0 +1,12 @@
+{% extends "account/email/base_message.txt" %}
+{% load i18n %}
+
+{% block content %}{% autoescape off %}{% blocktrans %}You are receiving this email because you or someone else has requested a
+password for your user account. However, we do not have any record of a user
+with email {{ email }} in our database.
+
+This mail can be safely ignored if you did not request a password reset.
+
+If it was you, you can sign up for an account using the link below.{% endblocktrans %}
+
+{{ signup_url }}{% endautoescape %}{% endblock content %}

--- a/templates/allauth/account/email/unknown_account_subject.txt
+++ b/templates/allauth/account/email/unknown_account_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password Reset Email{% endblocktrans %}
+{% endautoescape %}

--- a/templates/allauth/account/email_change.html
+++ b/templates/allauth/account/email_change.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}
+    {% trans "Email Address" %}
+{% endblock head_title %}
+{% block content %}
+    <h1>{% trans "Email Address" %}</h1>
+    {% if emailaddresses %}
+        {% if current_emailaddress %}
+            <p>
+                {% trans 'The following email address is associated with your account:' %} <a href="mailto:{{ current_emailaddress.email }}">{{ current_emailaddress.email }}</a>
+            </p>
+        {% endif %}
+        {% if new_emailaddress %}
+            <p>
+                {% trans 'Your email address is still pending verification:' %} <a href="mailto:{{ new_emailaddress.email }}">{{ new_emailaddress.email }}</a>
+            </p>
+            <form method="post" action="{% url 'account_email' %}">
+                {% csrf_token %}
+                <input type="hidden" name="email" value="{{ new_emailaddress.email }}">
+                <button type="submit" name="action_send">{% trans 'Re-send Verification' %}</button>
+            </form>
+        {% endif %}
+    {% else %}
+        {% include "account/snippets/warn_no_email.html" %}
+    {% endif %}
+    <h2>{% trans "Change Email Address" %}</h2>
+    <form method="post" action="{% url 'account_email' %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button name="action_add" type="submit">{% trans "Change Email" %}</button>
+    </form>
+{% endblock content %}

--- a/templates/allauth/account/email_confirm.html
+++ b/templates/allauth/account/email_confirm.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% load account %}
+
+{% block head_title %}{% trans "Confirm Email Address" %}{% endblock head_title %}
+
+
+{% block content %}
+<h1>{% trans "Confirm Email Address" %}</h1>
+
+{% if confirmation %}
+
+{% user_display confirmation.email_address.user as user_display %}
+
+{% if can_confirm %}
+<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.{% endblocktrans %}</p>
+
+<form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+{% csrf_token %}
+    <button type="submit">{% trans 'Confirm' %}</button>
+</form>
+{% else %}
+<p>{% blocktrans %}Unable to confirm {{ email }} because it is already confirmed by a different account.{% endblocktrans %}</p>
+{% endif %}
+
+{% else %}
+
+{% url 'account_email' as email_url %}
+
+<p>{% blocktrans %}This email confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new email confirmation request</a>.{% endblocktrans %}</p>
+
+{% endif %}
+
+{% endblock content %}

--- a/templates/allauth/account/login.html
+++ b/templates/allauth/account/login.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% load static %}
+{% load i18n %}
+{% load account socialaccount %}
+
+{% block head_title %}{% trans "Sign In" %}{% endblock head_title %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block content %}
+<div class="container">
+<div class="allauth">
+<h1>{% trans "Sign In" %}</h1>
+
+{% get_providers as socialaccount_providers %}
+
+{% if socialaccount_providers %}
+<p>{% blocktrans with site.name as site_name %}Please sign in with one
+of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
+for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+
+<div class="socialaccount_ballot">
+
+  <ul class="socialaccount_providers">
+    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+  </ul>
+
+  <div class="login-or">{% trans 'or' %}</div>
+
+</div>
+
+{% include "socialaccount/snippets/login_extra.html" %}
+
+{% else %}
+<p>{% blocktrans %}If you have not created an account yet, then please
+<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
+{% endif %}
+
+<form class="login" method="POST" action="{% url 'account_login' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+  <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
+</form>
+</div>
+</div>
+{% endblock %}

--- a/templates/allauth/account/logout.html
+++ b/templates/allauth/account/logout.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Sign Out" %}{% endblock head_title %}
+{% block content %}
+<div class="container">
+<div class="allauth">
+<h1>{% trans "Sign Out" %}</h1>
+
+<p>{% trans 'Are you sure you want to sign out?' %}</p>
+
+<form method="post" action="{% url 'account_logout' %}">
+  {% csrf_token %}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+  {% endif %}
+  <button type="submit">{% trans 'Sign Out' %}</button>
+</form>
+</div>
+</div>
+
+{% endblock content %}

--- a/templates/allauth/account/messages/cannot_delete_primary_email.txt
+++ b/templates/allauth/account/messages/cannot_delete_primary_email.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}You cannot remove your primary email address ({{email}}).{% endblocktrans %}

--- a/templates/allauth/account/messages/email_confirmation_failed.txt
+++ b/templates/allauth/account/messages/email_confirmation_failed.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Unable to confirm {{email}} because it is already confirmed by a different account.{% endblocktrans %}

--- a/templates/allauth/account/messages/email_confirmation_sent.txt
+++ b/templates/allauth/account/messages/email_confirmation_sent.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Confirmation email sent to {{email}}.{% endblocktrans %}

--- a/templates/allauth/account/messages/email_confirmed.txt
+++ b/templates/allauth/account/messages/email_confirmed.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}You have confirmed {{email}}.{% endblocktrans %}

--- a/templates/allauth/account/messages/email_deleted.txt
+++ b/templates/allauth/account/messages/email_deleted.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Removed email address {{email}}.{% endblocktrans %}

--- a/templates/allauth/account/messages/logged_in.txt
+++ b/templates/allauth/account/messages/logged_in.txt
@@ -1,0 +1,4 @@
+{% load account %}
+{% load i18n %}
+{% user_display user as name %}
+{% blocktrans %}Successfully signed in as {{name}}.{% endblocktrans %}

--- a/templates/allauth/account/messages/logged_out.txt
+++ b/templates/allauth/account/messages/logged_out.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}You have signed out.{% endblocktrans %}

--- a/templates/allauth/account/messages/password_changed.txt
+++ b/templates/allauth/account/messages/password_changed.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Password successfully changed.{% endblocktrans %}

--- a/templates/allauth/account/messages/password_set.txt
+++ b/templates/allauth/account/messages/password_set.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Password successfully set.{% endblocktrans %}

--- a/templates/allauth/account/messages/primary_email_set.txt
+++ b/templates/allauth/account/messages/primary_email_set.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Primary email address set.{% endblocktrans %}

--- a/templates/allauth/account/messages/unverified_primary_email.txt
+++ b/templates/allauth/account/messages/unverified_primary_email.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% blocktrans %}Your primary email address must be verified.{% endblocktrans %}

--- a/templates/allauth/account/password_change.html
+++ b/templates/allauth/account/password_change.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Change Password" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Change Password" %}</h1>
+
+    <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" name="action">{% trans "Change Password" %}</button>
+        <a href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+    </form>
+{% endblock content %}

--- a/templates/allauth/account/password_reset.html
+++ b/templates/allauth/account/password_reset.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% load i18n %}
+{% load account %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Password Reset" %}{% endblock head_title %}
+
+{% block content %}
+<div class="container">
+    <h1>{% trans "Password Reset" %}</h1>
+    {% if user.is_authenticated %}
+    {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+
+    <p>{% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}</p>
+
+    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="{% trans 'Reset My Password' %}" />
+    </form>
+
+    <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>
+</div>
+{% endblock content %}

--- a/templates/allauth/account/password_reset_done.html
+++ b/templates/allauth/account/password_reset_done.html
@@ -1,0 +1,18 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Password Reset" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Password Reset" %}</h1>
+    
+    {% if user.is_authenticated %}
+    {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    
+    <p>{% blocktrans %}We have sent you an email. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}</p>
+{% endblock content %}

--- a/templates/allauth/account/password_reset_from_key.html
+++ b/templates/allauth/account/password_reset_from_key.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Change Password" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+
+    {% if token_fail %}
+        {% url 'account_reset_password' as passwd_reset_url %}
+        <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
+    {% else %}
+        <form method="POST" action="{{ action_url }}" class="password_reset_from_key">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" name="action" value="{% trans 'change password' %}"/>
+        </form>
+    {% endif %}
+{% endblock content %}

--- a/templates/allauth/account/password_reset_from_key_done.html
+++ b/templates/allauth/account/password_reset_from_key_done.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Change Password" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Change Password" %}</h1>
+    <p>{% trans 'Your password is now changed.' %}</p>
+{% endblock content %}

--- a/templates/allauth/account/password_set.html
+++ b/templates/allauth/account/password_set.html
@@ -1,0 +1,17 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Set Password" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Set Password" %}</h1>
+
+    <form method="POST" action="{% url 'account_set_password' %}" class="password_set">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" name="action" value="{% trans 'Set Password' %}"/>
+    </form>
+{% endblock content %}

--- a/templates/allauth/account/reauthenticate.html
+++ b/templates/allauth/account/reauthenticate.html
@@ -1,0 +1,24 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Confirm Access" %}{% endblock head_title %}
+
+{% block content %}
+
+<h1>{% trans "Confirm Access" %}</h1>
+
+<p>{% blocktranslate %}To safeguard the security of your account, please enter your password:{% endblocktranslate %}</p>
+
+<form class="reauthenticate" method="POST" action="{% url 'account_reauthenticate' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <button type="submit">{% trans "Confirm" %}</button>
+</form>
+
+{% endblock content %}

--- a/templates/allauth/account/signup.html
+++ b/templates/allauth/account/signup.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load static %}
+{% load i18n %}
+
+{% block head_title %}{% trans "Signup" %}{% endblock head_title %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block content %}
+<div class="container">
+  <div class="allauth">
+<h1>{% trans "Sign Up" %}</h1>
+
+<p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
+
+<form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <button type="submit">{% trans "Sign Up" %} &raquo;</button>
+</form>
+</div>
+</div>
+{% endblock content %}

--- a/templates/allauth/account/signup_closed.html
+++ b/templates/allauth/account/signup_closed.html
@@ -1,0 +1,13 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Sign Up Closed" %}{% endblock head_title %}
+
+{% block content %}
+<h1>{% trans "Sign Up Closed" %}</h1>
+
+<p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
+{% endblock content %}

--- a/templates/allauth/account/snippets/already_logged_in.html
+++ b/templates/allauth/account/snippets/already_logged_in.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% load account %}
+
+{% user_display user as user_display %}
+<p><strong>{% trans "Note" %}:</strong> {% blocktrans %}you are already logged in as {{ user_display }}.{% endblocktrans %}</p>

--- a/templates/allauth/account/snippets/warn_no_email.html
+++ b/templates/allauth/account/snippets/warn_no_email.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+<p>
+    <strong>{% trans 'Warning:' %}</strong> {% trans "You currently do not have any email address set up. You should really add an email address so you can receive notifications, reset your password, etc." %}
+</p>

--- a/templates/allauth/account/verification_sent.html
+++ b/templates/allauth/account/verification_sent.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock head_title %}
+
+{% block content %}
+    <h1>{% trans "Verify Your Email Address" %}</h1>
+
+    <p>{% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process. If you do not see the verification email in your main inbox, check your spam folder. Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}</p>
+
+{% endblock content %}

--- a/templates/allauth/account/verified_email_required.html
+++ b/templates/allauth/account/verified_email_required.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% block css %}
+<link rel="stylesheet" href="{% static 'css/index.css' %}">
+{% endblock %}
+{% block head_title %}{% trans "Verify Your Email Address" %}{% endblock head_title %}
+
+{% block content %}
+<h1>{% trans "Verify Your Email Address" %}</h1>
+
+{% url 'account_email' as email_url %}
+
+<p>{% blocktrans %}This part of the site requires us to verify that
+you are who you claim to be. For this purpose, we require that you
+verify ownership of your email address. {% endblocktrans %}</p>
+
+<p>{% blocktrans %}We have sent an email to you for
+verification. Please click on the link inside that email. If you do not see the verification email in your main inbox, check your spam folder. Otherwise
+contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+
+<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your email address</a>.{% endblocktrans %}</p>
+
+
+{% endblock content %}


### PR DESCRIPTION
…ed to template folder

Email verification added - currently db and email inf is in env.py, can send privately before making the config vars on heroku when deploying. With authentication added, we can now work on the account homepage and account models for user emergency contacts